### PR TITLE
feat(graph): Add responsive design for mobile and tablet screens

### DIFF
--- a/graph/graph.html
+++ b/graph/graph.html
@@ -17,9 +17,9 @@
     #cy {
         width: var(--screen-width);
         height: var(--screen-height);
-        left: 25px;
         position: relative;
         margin: 0 auto;
+        left: 0;
         /* width: 80vw;
         height: 80vh; */
         /* position: absolute; */
@@ -217,10 +217,6 @@
             top: 110px;
         }
         
-        #cy {
-            left: 10px;
-        }
-        
         .nav-btn-container button,
         .bottom-btn-container button {
             font-size: 13px;
@@ -252,10 +248,6 @@
             right: 5px;
             left: auto;
             top: 80px;
-        }
-        
-        #cy {
-            left: 5px;
         }
         
         .nav-btn-container {
@@ -591,33 +583,35 @@
             var screenWidth = window.innerWidth;
             var screenHeight = window.innerHeight;
             
-            // Responsive width calculation based on screen size
-            var graphWidth, graphLeft;
+            // Responsive width and height calculation based on screen size
+            // All sizes use centered layout with auto margins
+            var graphWidth, graphHeight;
             if (screenWidth <= 600) {
-                // Mobile: use more screen space
+                // Mobile: use more screen space, reduce height for buttons
                 graphWidth = screenWidth * 0.95;
-                graphLeft = '2.5%';
+                graphHeight = screenHeight * 0.70; // Leave room for top nav and bottom buttons
             } else if (screenWidth <= 900) {
                 // Tablet: moderate margins
-                graphWidth = screenWidth * 0.88;
-                graphLeft = '6%';
+                graphWidth = screenWidth * 0.90;
+                graphHeight = screenHeight * 0.80;
             } else {
-                // Desktop: original behavior
-                graphWidth = screenWidth * 0.8;
-                graphLeft = '10%';
+                // Desktop: centered layout
+                graphWidth = screenWidth * 0.85;
+                graphHeight = screenHeight * 0.90;
             }
             
             // Set CSS variables with screen dimensions
             document.documentElement.style.setProperty('--screen-width', graphWidth + 'px');
-            document.documentElement.style.setProperty('--screen-height', screenHeight + 'px');
+            document.documentElement.style.setProperty('--screen-height', graphHeight + 'px');
             
-            // Update graph container position
+            // Update graph container position - centered with auto margins
             var cyContainer = document.getElementById('cy');
             if (cyContainer) {
-                cyContainer.style.left = graphLeft;
+                cyContainer.style.left = '0';
+                cyContainer.style.margin = '0 auto';
             }
             
-            return { screenWidth, screenHeight, graphWidth };
+            return { screenWidth, screenHeight, graphWidth, graphHeight };
         }
         
         // Initial call
@@ -871,16 +865,51 @@
             return 24;
         }
         
+        // Debounce helper to avoid excessive updates
+        function debounce(func, wait) {
+            let timeout;
+            return function executedFunction(...args) {
+                const later = () => {
+                    clearTimeout(timeout);
+                    func(...args);
+                };
+                clearTimeout(timeout);
+                timeout = setTimeout(later, wait);
+            };
+        }
+        
         // Window resize handler for Cytoscape
-        window.addEventListener('resize', function() {
+        window.addEventListener('resize', debounce(function() {
             // Update CSS variables for graph container size
             updateScreenDimensions();
+            updateInfoBoxSize();
             
             if (cyInstance) {
+                // Update node and edge styles based on new screen size
+                const nodeFontSize = getResponsiveFontSize();
+                const edgeFontSize = Math.max(12, nodeFontSize - 4);
+                const textMaxWidth = window.innerWidth <= 600 ? 100 : 150;
+                const edgeTextMaxWidth = window.innerWidth <= 600 ? 60 : 100;
+                
+                // Apply updated styles
+                cyInstance.style()
+                    .selector('node')
+                    .style({
+                        'font-size': nodeFontSize,
+                        'text-max-width': textMaxWidth
+                    })
+                    .selector('edge')
+                    .style({
+                        'font-size': edgeFontSize,
+                        'text-max-width': edgeTextMaxWidth
+                    })
+                    .update();
+                
+                // Resize container and fit graph
                 cyInstance.resize();
                 cyInstance.fit();
             }
-        });
+        }, 150));
         
         // async function to create and draw the graph
         async function createNetwork(sub_graph = '') {

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -1080,12 +1080,49 @@
             const maxZoom = 1.2; // maximum allowed zoom level
             // get cyto .css element first
             var cytoCSS = document.body;
+            // Shared function for context action on background/anywhere
+            function handleBackgroundContextAction(isNode) {
+                cytoCSS.style.backgroundImage = 'url("ARIADNE_Logo.png")';
+                const tooltips = document.querySelectorAll('.custom-tooltip');
+                tooltips.forEach(tooltip => tooltip.remove());
+                createNetwork('initial');
+                if (!isNode) {
+                    updateKeyContent('', 'right_click');
+                }
+                cyto.zoom(minZoom);
+            }
+
+            // Shared function for context action on nodes
+            function handleNodeContextAction(node) {
+                var auxElem = graphPathArr[index-1];
+                
+                if (auxElem != 'initial'){
+                    cytoCSS.style.backgroundImage = 'url("")';
+                } else if (auxElem == 'initial'){
+                    updateKeyContent('', 'right_click');
+                }
+                createNetwork(auxElem.replace(' ',''));
+            }
             if (index == 0){ // if it's the first iteration
                 cyto = await createNetwork('initial'); // draw the initial overview
             }
             else{ // if it's not the first iteration
                 // if there is a left click on a node
                 cyto.on('click', 'node', function(event) {
+                    cytoCSS.style.backgroundImage = 'url("")'; // remove background image
+                    var node = event.target; // get the node
+                    if (node.data('is_terminal') == 'no'){ // if it's not a terminal node
+                        createNetwork(node.data('id').replaceAll(' ','')); // and give it to the network function as 'subgraph'
+                        if (node.data('mainGraph') == 'initial'){ // only if it's an initial node we should show the key questions
+                            updateKeyContent(node, 'left_click'); // Call the function to update key content
+                        }
+                    }
+                    else{ // if it's a terminal node
+                        window.open(node.data('tooltip'), '_blank'); // redirect to the respective webpage
+                    }
+                });
+                // if there is a tap on a node; do the same as left click because mobile phones do not have left click
+                cyto.on('tap', 'node', function(event) {
                     cytoCSS.style.backgroundImage = 'url("")'; // remove background image
                     var node = event.target; // get the node
                     if (node.data('is_terminal') == 'no'){ // if it's not a terminal node
@@ -1157,6 +1194,44 @@
                     }
                     cyto.center(); // center the whole graph to viewport 
                 });
+                // following block is for long press to go one level up alternative for mobile
+                // ===== MOBILE: Long-press handlers =====
+                let pressTimer;
+                let pressTarget = null;
+
+                // Long-press on node
+                cyto.on('tapstart', 'node', function(event) {
+                    const node = event.target;
+                    pressTarget = node;
+                    pressTimer = setTimeout(function() {
+                        handleNodeContextAction(node);
+                        pressTarget = null;
+                    }, 600);
+                });
+
+                // Long-press on background
+                cyto.on('tapstart', function(event) {
+                    // Check if it's the background (not a node or edge)
+                    try {
+                        var isNode = event.target.isNode();
+                    } catch (error) {
+                        var isNode = false;
+                    }
+                    
+                    if (!isNode && event.target === cyto) {
+                        pressTimer = setTimeout(function() {
+                            handleBackgroundContextAction(false);
+                        }, 600);
+                    }
+                });
+
+                // Cancel long-press on tap end or drag
+                cyto.on('tapend drag', function() {
+                    clearTimeout(pressTimer);
+                    pressTarget = null;
+                });
+                //
+
             }
         }
         function updateKeyContent(node, clickType) {

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -18,6 +18,8 @@
         width: var(--screen-width);
         height: var(--screen-height);
         left: 25px;
+        position: relative;
+        margin: 0 auto;
         /* width: 80vw;
         height: 80vh; */
         /* position: absolute; */
@@ -34,10 +36,11 @@
     }
     .info-box {
         font-family: Helvetica;
-        font-size: 14px;
-        position: absolute;
+        font-size: 15px;
+        position: fixed;
         top: 10px;
         right: 10px;
+        left: auto;
         width: 300px;
         background-color: #ffffff;
         border: 1px solid #cccccc;
@@ -45,17 +48,39 @@
         border-radius: 5px;
         box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.2);
         cursor: pointer;
-        z-index: 2;
+        z-index: 9998;
     }
     .info-box.show {
         display: none;
     }
+    /* Optimize list spacing inside info-box and key-box */
+    .info-box ul,
+    .key-box ul {
+        margin: 5px 0;
+        padding-left: 18px;
+    }
+    .info-box li,
+    .key-box li {
+        margin-bottom: 4px;
+        line-height: 1.3;
+    }
+    #infoContent,
+    #keyContent {
+        margin: 0;
+        padding: 0;
+    }
+    .info-box h2,
+    .key-box h2 {
+        margin: 0 0 5px 0;
+        font-size: 16px;
+    }
     .key-box {
         font-family: Helvetica;
-        font-size: 14px;
-        position: absolute;
+        font-size: 15px;
+        position: fixed;
         top: 120px;
         right: 10px;
+        left: auto;
         width: 300px;
         background-color: #ffffff;
         border: 1px solid #cccccc;
@@ -63,7 +88,7 @@
         border-radius: 5px;
         box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.2);
         cursor: pointer;
-        z-index: 1;
+        z-index: 9997;
     }
     .key-box.show {
         display: none;
@@ -81,140 +106,275 @@
         background-position: center center;
         /* position: relative; */
     }
-    .back-button {
-        position: fixed;
-        top: 20px; /* Adjust the top distance from the top of the screen */
-        left: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16.5px;
-        background-color: #4CAF50;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
-    .back-button:hover {
-        background-color: #45a049;
-    }
-    .osf-button {
-        position: fixed;
-        top: 85px; /* Adjust the top distance from the top of the screen */
-        left: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16.5px;
-        background-color: #4CAF50;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
-    .osf-button:hover {
-        background-color: #45a049;
-    }
+    /* Shared button styles - positions now controlled by containers */
+    .back-button,
+    .osf-button,
     .glos-button {
-        position: fixed;
-        top: 150px; /* Adjust the top distance from the top of the screen */
-        left: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16.5px;
+        font-size: 15px;
         background-color: #4CAF50;
         color: white;
         border: none;
-        padding: 10px 20px;
+        padding: 10px 16px;
         border-radius: 5px;
         cursor: pointer;
         transition: background-color 0.3s;
+        white-space: nowrap;
     }
+    .back-button:hover,
+    .osf-button:hover,
     .glos-button:hover {
         background-color: #45a049;
     }
-    /*suggestion buttons*/
-    .sugg-ghub-button {  /*change the name to gdrive & ghub*/
-        position: absolute;
-        bottom: 10px; /* Adjust the top distance from the top of the screen */
-        left: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16px;
+    /* Suggestion & Bug buttons - positions now controlled by containers */
+    .sugg-ghub-button,
+    .sugg-gdrive-button,
+    .bug-ghub-button,
+    .bug-gdrive-button {
+        font-size: 14px;
         background-color: #4CAF50;
         color: white;
         border: none;
-        padding: 10px 20px;
+        padding: 10px 14px;
         border-radius: 5px;
         cursor: pointer;
         transition: background-color 0.3s;
+        white-space: nowrap;
     }
-    .sugg-ghub-button:hover {
-        background-color: #45a049;
-    }
-    .sugg-gdrive-button { /*change the name to gdrive & ghub*/
-        position: absolute;
-        bottom: 50px; /* Adjust the top distance from the top of the screen */
-        left: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16px;
-        background-color: #4CAF50;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
-    .sugg-gdrive-button:hover {
-        background-color: #45a049;
-    }
-    /*bug buttons*/
-    .bug-ghub-button {  /*change the name to gdrive & ghub*/
-        position: absolute;
-        bottom: 10px; /* Adjust the top distance from the top of the screen */
-        right: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16px;
-        background-color: #4CAF50;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
-    .bug-ghub-button:hover {
-        background-color: #45a049;
-    }
-    .bug-gdrive-button { /*change the name to gdrive & ghub*/
-        position: absolute;
-        bottom: 50px; /* Adjust the top distance from the top of the screen */
-        right: 20px; /* Adjust the left distance from the left side of the screen */
-        z-index: 9999; /* Ensure the button appears above other elements */
-        font-size: 16px;
-        background-color: #4CAF50;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
+    .sugg-ghub-button:hover,
+    .sugg-gdrive-button:hover,
+    .bug-ghub-button:hover,
     .bug-gdrive-button:hover {
         background-color: #45a049;
     }
     /* .bullet-resource { list-style-type: disc; color: #D41159; } */
+
+    /* ===== RESPONSIVE DESIGN ===== */
+    
+    /* Button containers for better organization */
+    .nav-btn-container {
+        position: fixed;
+        top: 10px;
+        left: 10px;
+        z-index: 9999;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+    
+    .bottom-btn-container {
+        position: fixed;
+        bottom: 10px;
+        left: 10px;
+        right: 10px;
+        z-index: 9999;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 8px;
+        pointer-events: none;
+    }
+    
+    .bottom-btn-container button {
+        pointer-events: auto;
+    }
+    
+    .bottom-left-group,
+    .bottom-right-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+    
+    /* Common button base styles */
+    .nav-btn-container button,
+    .bottom-btn-container button {
+        font-size: 14px;
+        padding: 8px 14px;
+        position: relative;
+        top: auto;
+        left: auto;
+        right: auto;
+        bottom: auto;
+    }
+    
+    /* Medium screens (tablets) */
+    @media (max-width: 900px) {
+        .info-box {
+            width: 220px;
+            font-size: 13px;
+            padding: 8px;
+            right: 10px;
+            left: auto;
+            top: 10px;
+        }
+        
+        .key-box {
+            width: 220px;
+            font-size: 13px;
+            padding: 8px;
+            right: 10px;
+            left: auto;
+            top: 110px;
+        }
+        
+        #cy {
+            left: 10px;
+        }
+        
+        .nav-btn-container button,
+        .bottom-btn-container button {
+            font-size: 13px;
+            padding: 8px 12px;
+        }
+
+        body {
+            background-size: 200px 200px;
+        }
+    }
+    
+    /* Mobile screens */
+    @media (max-width: 600px) {
+        .info-box {
+            width: auto;
+            max-width: 180px;
+            font-size: 11px;
+            padding: 6px;
+            right: 5px;
+            left: auto;
+            top: 5px;
+        }
+        
+        .key-box {
+            width: auto;
+            max-width: 180px;
+            font-size: 11px;
+            padding: 6px;
+            right: 5px;
+            left: auto;
+            top: 80px;
+        }
+        
+        #cy {
+            left: 5px;
+        }
+        
+        .nav-btn-container {
+            top: 5px;
+            left: 5px;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 4px;
+            max-width: none;
+        }
+        
+        .nav-btn-container button {
+            font-size: 11px;
+            padding: 5px 8px;
+            width: auto;
+        }
+        
+        .bottom-btn-container {
+            flex-direction: column;
+            align-items: stretch;
+            bottom: 5px;
+            left: 5px;
+            right: 5px;
+        }
+        
+        .bottom-left-group,
+        .bottom-right-group {
+            flex-direction: row;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            gap: 5px;
+        }
+        
+        .bottom-btn-container button {
+            font-size: 10px;
+            padding: 6px 8px;
+            flex: 1 1 auto;
+            max-width: calc(50% - 5px);
+        }
+        
+        .custom-tooltip {
+            max-width: calc(100vw - 40px);
+            font-size: 12px;
+            padding: 8px;
+        }
+
+        body {
+            background-size: 150px 150px;
+        }
+        
+        #shapesCanvas {
+            width: 100%;
+            max-width: 200px;
+            height: auto;
+        }
+    }
+    
+    /* Extra small screens */
+    @media (max-width: 400px) {
+        .nav-btn-container button {
+            font-size: 10px;
+            padding: 5px 6px;
+        }
+        
+        .bottom-btn-container button {
+            font-size: 9px;
+            padding: 5px 6px;
+        }
+        
+        .info-box, .key-box {
+            font-size: 11px;
+        }
+    }
+    
+    /* Large screens */
+    @media (min-width: 1200px) {
+        .info-box, .key-box {
+            font-size: 16px;
+            width: 340px;
+        }
+        
+        .info-box h2, .key-box h2 {
+            font-size: 18px;
+        }
+        
+        .nav-btn-container button {
+            font-size: 16px;
+            padding: 12px 18px;
+        }
+        
+        .bottom-btn-container button {
+            font-size: 15px;
+            padding: 10px 16px;
+        }
+    }
   </style>
   <script src="./cytoscape/cytoscape.min.js"></script>
   
 </head>
 <body>
-    <button id="back-button" class="back-button" title="For more information, see the ARIADNE book">←<br>ARIADNE Book</button>
-    <button id="osf-button" class="osf-button" title="Go to the OSF repository to see the complete resource table">←<br>OSF Repository</button>
-    <button id="glos-button" class="glos-button" title="Go to the Glossary of terms used">←<br>Glossary</button>
-    <button id="sugg-gdrive-button" class="sugg-gdrive-button" title="If you have a new resource to suggest; please report them to us via Google Forms!">Suggest new resource via Google Forms</button>
-    <button id="sugg-ghub-button" class="sugg-ghub-button" title="If you have a new resource to suggest; please report them to us via GitHub issues!">Suggest new resource via GitHub</button>
-    <button id="bug-gdrive-button" class="bug-gdrive-button" title="If you have a a bug that you have encountered; please report them to us via Google Forms!">Report a bug via Google Forms</button>
-    <button id="bug-ghub-button" class="bug-ghub-button" title="If you have a bug that you have encountered; please report them to us via GitHub issues!">Report a bug via GitHub</button>
+    <!-- Top-left navigation buttons -->
+    <div class="nav-btn-container">
+        <button id="back-button" class="back-button" title="For more information, see the ARIADNE book">← ARIADNE Book</button>
+        <button id="osf-button" class="osf-button" title="Go to the OSF repository to see the complete resource table">← OSF Repository</button>
+        <button id="glos-button" class="glos-button" title="Go to the Glossary of terms used">← Glossary</button>
+    </div>
+    
+    <!-- Bottom action buttons -->
+    <div class="bottom-btn-container">
+        <div class="bottom-left-group">
+            <button id="sugg-gdrive-button" class="sugg-gdrive-button" title="If you have a new resource to suggest; please report them to us via Google Forms!">+ Suggest new resource via Google Forms</button>
+            <button id="sugg-ghub-button" class="sugg-ghub-button" title="If you have a new resource to suggest; please report them to us via GitHub issues!">+ Suggest new resource via GitHub</button>
+        </div>
+        <div class="bottom-right-group">
+            <button id="bug-gdrive-button" class="bug-gdrive-button" title="If you have a bug that you have encountered; please report them to us via Google Forms!">Report a bug via Google Forms</button>
+            <button id="bug-ghub-button" class="bug-ghub-button" title="If you have a bug that you have encountered; please report them to us via GitHub issues!">Report a bug via GitHub</button>
+        </div>
+    </div>
+    
     <div id="cy"></div>
     <div id="info-box" class="info-box">
         <span id="infoTitle"><h2>Instructions:</h2> Click to hide/unhide the instructions</span>
@@ -426,21 +586,90 @@
 
 
   <script>
-        // Get the width and height of the screen
-        var screenWidth = window.innerWidth*0.8;
-        var screenHeight = window.innerHeight;
-        // Set CSS variables with screen width and height
-        // document.documentElement.style.setProperty('--screen-width', screenWidth + 'px');
-        // document.documentElement.style.setProperty('--screen-height', screenHeight*0.8 + 'px');
-        document.documentElement.style.setProperty('--screen-width', screenWidth+ 'px');
-        document.documentElement.style.setProperty('--screen-height', screenHeight + 'px');
+        // Get the width and height of the screen - responsive calculation
+        function updateScreenDimensions() {
+            var screenWidth = window.innerWidth;
+            var screenHeight = window.innerHeight;
+            
+            // Responsive width calculation based on screen size
+            var graphWidth, graphLeft;
+            if (screenWidth <= 600) {
+                // Mobile: use more screen space
+                graphWidth = screenWidth * 0.95;
+                graphLeft = '2.5%';
+            } else if (screenWidth <= 900) {
+                // Tablet: moderate margins
+                graphWidth = screenWidth * 0.88;
+                graphLeft = '6%';
+            } else {
+                // Desktop: original behavior
+                graphWidth = screenWidth * 0.8;
+                graphLeft = '10%';
+            }
+            
+            // Set CSS variables with screen dimensions
+            document.documentElement.style.setProperty('--screen-width', graphWidth + 'px');
+            document.documentElement.style.setProperty('--screen-height', screenHeight + 'px');
+            
+            // Update graph container position
+            var cyContainer = document.getElementById('cy');
+            if (cyContainer) {
+                cyContainer.style.left = graphLeft;
+            }
+            
+            return { screenWidth, screenHeight, graphWidth };
+        }
+        
+        // Initial call
+        var dims = updateScreenDimensions();
+        var screenWidth = dims.screenWidth;
+        var screenHeight = dims.screenHeight;
+        
         // Also the size of the info box
         function updateInfoBoxSize() {
-            screenWidth = window.innerWidth;
+            dims = updateScreenDimensions();
+            screenWidth = dims.screenWidth;
             var infoBox = document.getElementById('info-box');
-            // Adjust the width of the info box based on the screen width
-            infoBox.style.width = screenWidth >= 768 ? '300px' : '150px';
-            // You can add additional size adjustments based on screen width if needed
+            var keyBox = document.getElementById('key-box');
+            
+            // Adjust the width and position of boxes based on screen width
+            if (screenWidth <= 600) {
+                // Mobile: smaller width, positioned on right to avoid nav buttons
+                infoBox.style.width = 'auto';
+                infoBox.style.maxWidth = '180px';
+                infoBox.style.right = '5px';
+                infoBox.style.left = 'auto';
+                if (keyBox) {
+                    keyBox.style.width = 'auto';
+                    keyBox.style.maxWidth = '180px';
+                    keyBox.style.right = '5px';
+                    keyBox.style.left = 'auto';
+                }
+            } else if (screenWidth <= 900) {
+                // Tablet: moderate width
+                infoBox.style.width = '220px';
+                infoBox.style.maxWidth = '';
+                infoBox.style.right = '10px';
+                infoBox.style.left = 'auto';
+                if (keyBox) {
+                    keyBox.style.width = '220px';
+                    keyBox.style.maxWidth = '';
+                    keyBox.style.right = '10px';
+                    keyBox.style.left = 'auto';
+                }
+            } else {
+                // Desktop
+                infoBox.style.width = '300px';
+                infoBox.style.maxWidth = '';
+                infoBox.style.right = '10px';
+                infoBox.style.left = 'auto';
+                if (keyBox) {
+                    keyBox.style.width = '300px';
+                    keyBox.style.maxWidth = '';
+                    keyBox.style.right = '10px';
+                    keyBox.style.left = 'auto';
+                }
+            }
         }
         // Call the function when the window is resized
         window.addEventListener('resize', updateInfoBoxSize);
@@ -630,6 +859,29 @@
         let index = 0;
         // get previous subgraph
         let graphPathArr = [];
+        // Global reference to current Cytoscape instance for resize handling
+        let cyInstance = null;
+        
+        // Helper function to get responsive font size
+        function getResponsiveFontSize() {
+            var width = window.innerWidth;
+            if (width <= 400) return 14;
+            if (width <= 600) return 16;
+            if (width <= 900) return 20;
+            return 24;
+        }
+        
+        // Window resize handler for Cytoscape
+        window.addEventListener('resize', function() {
+            // Update CSS variables for graph container size
+            updateScreenDimensions();
+            
+            if (cyInstance) {
+                cyInstance.resize();
+                cyInstance.fit();
+            }
+        });
+        
         // async function to create and draw the graph
         async function createNetwork(sub_graph = '') {
             // wait for nodes
@@ -659,6 +911,9 @@
             const filteredEdges = edgesArray.filter(item => item.data?.subgraph?.toLowerCase() === sub_graph?.toLowerCase());
             // now combine the arrays
             const filteredAll = filteredNodes.concat(filteredEdges);
+            // Get responsive font size
+            const nodeFontSize = getResponsiveFontSize();
+            const edgeFontSize = Math.max(12, nodeFontSize - 4);
                 // configure the cytoscape graph here
                 const cy = cytoscape({
                     container: document.getElementById('cy'), // will be drawn on div tag 'cy'
@@ -670,9 +925,9 @@
                             'background-color': 'data(background_color)',
                             'shape': 'data(shape)',
                             'label': 'data(label)',
-                            'font-size': 24,
+                            'font-size': nodeFontSize,
                             'text-wrap': 'wrap', // or 'ellipsis' for truncation
-                            'text-max-width': 150, // Set the maximum width for wrapped text
+                            'text-max-width': window.innerWidth <= 600 ? 100 : 150, // Responsive text width
                             'background-width': '80%', // those four variables fix the position of the images
                             'background-height': '80%', // those four variables fix the position of the images
                             'background-offset-x' : '140%', // those four variables fix the position of the images
@@ -704,12 +959,12 @@
                         selector: 'edge', // edge style
                         style: {
                             'width': 2,
-                            'font-size': 24,
+                            'font-size': edgeFontSize,
                             'line-color': '#ccc',
                             'target-arrow-color': '#ccc',
                             'target-arrow-shape': 'triangle',
                             'text-wrap': 'wrap',
-                            'text-max-width': 100,
+                            'text-max-width': window.innerWidth <= 600 ? 60 : 100,
                             'text-wrap': 'wrap',
                             'label': 'data(label)'
                         }
@@ -774,6 +1029,8 @@
                     });
                     styleOptions.run();
                 }
+                // Store reference to current cy instance for resize handling
+                cyInstance = cy;
                 main(index, cy, graphPathArr); // and now call the main function so we run it indefinitely
                 index += 1; // increase the index because we run the code once already
                 // in the next block, keybox is set

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -1012,7 +1012,9 @@
                 edge.data.id = 'node_' + Math.random().toString(36).substr(2, 9);
             }
             });
-            graphPathArr.push(sub_graph);
+            if (graphPathArr[graphPathArr.length - 1] !== sub_graph) {
+                graphPathArr.push(sub_graph);
+            }
             // filter the nodes&edges wrt. to selected node's subgraph
             const filteredNodes = nodesArray.filter(item => item.data?.subgraph?.toLowerCase() === sub_graph?.toLowerCase());
             const filteredEdges = edgesArray.filter(item => item.data?.subgraph?.toLowerCase() === sub_graph?.toLowerCase());
@@ -1171,10 +1173,13 @@
             }
 
             // Shared function for context action on nodes
-            function handleNodeContextAction(node) {
+            function handleNodeContextAction() {
                 const tooltips = document.querySelectorAll('.custom-tooltip');
                 tooltips.forEach(tooltip => tooltip.remove());
-                var auxElem = graphPathArr[index-2];
+                if (graphPathArr.length > 0) {
+                    graphPathArr.pop();
+                }
+                var auxElem = graphPathArr[graphPathArr.length - 1];
                 if (!auxElem) {
                     auxElem = 'initial';
                 }
@@ -1184,7 +1189,7 @@
                 } else {
                     cytoCSS.style.backgroundImage = 'url("")';
                 }
-                createNetwork(auxElem.replace(' ',''));
+                createNetwork(auxElem.replaceAll(' ',''));
             }
 
             // Function to handle terminal node interactions (hover/tap)
@@ -1246,6 +1251,8 @@
             }
             else{ // if it's not the first iteration
                 const isMobileOrTablet = isMobileOrTabletDevice();
+                let pressTimer = null;
+                let pressTarget = null;
 
                 if (!isMobileOrTablet) {
                     // Desktop interactions
@@ -1281,8 +1288,8 @@
 
                     // Right click on a node → Go one level up (back to parent graph)
                     cyto.on('cxttap', 'node', function(event) {
-                        const node = event.target;
-                        handleNodeContextAction(node);
+                        if (event.target === cyto) return;
+                        handleNodeContextAction();
                     });
                 } else {
                     // Mobile/Tablet interactions
@@ -1347,8 +1354,8 @@
                     });
 
                     // Long press handlers for mobile (already implemented but let's improve them)
-                    let pressTimer;
-                    let pressTarget = null;
+                    pressTimer = null;
+                    pressTarget = null;
 
                     // Long-press on node
                     cyto.on('tapstart', 'node', function(event) {

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -379,6 +379,7 @@
             <li>Left click on the resource nodes to go to the respective webpages.</li>
             <li>Drag and drop on the nodes to rearrange the graph</li>
             <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
+            </ul>
             <canvas id="shapesCanvas" width="280" height="140"></canvas>
         </div>
     </div>
@@ -390,56 +391,88 @@
         </div>
     </div>
     <script>
-        // Get the canvas element
-        var canvas = document.getElementById("shapesCanvas");
-        var ctx = canvas.getContext("2d");
-
-        // Define shapes and their respective popup messages
+        // Canvas variables
+        var canvas, ctx;
         var shapes = [
-            { x: 0, y: 20, width: 40, height: 40, color: "#005AB5", rect: true, 
+            { x: 0, y: 20, width: 40, height: 40, color: "#005AB5", rect: true,
             popupMessage: "Initial node, there are more nodes inside this one!" },
-            { x: 130, y: 40, radius: 20, color: "#D41159", 
-            popupMessage: "Final node. Click this node to go to the resource's website!" }, 
-            { x: 55, y: 20, width: 40, height: 40, color: "#40B0A6", diamond: true, 
+            { x: 130, y: 40, radius: 20, color: "#D41159",
+            popupMessage: "Final node. Click this node to go to the resource's website!" },
+            { x: 55, y: 20, width: 40, height: 40, color: "#40B0A6", diamond: true,
             popupMessage: "Decision node, filter the nodes and move deeper!" },
-            { 
-                x: 0, y: 80, width: 35, height: 35, 
-                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/closed_lock_with_key.png", 
-                popupMessage: "Hybrid (partially) open access resource!" 
+            {
+                x: 0, y: 80, width: 35, height: 35,
+                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/closed_lock_with_key.png",
+                popupMessage: "Hybrid (partially) open access resource!"
             },
-            { 
-                x: 50, y: 80, width: 35, height: 35, 
-                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/lock.png", 
-                popupMessage: "Fully closed access resource!" 
+            {
+                x: 50, y: 80, width: 35, height: 35,
+                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/lock.png",
+                popupMessage: "Fully closed access resource!"
             },
-            { 
-                x: 100, y: 80, width: 35, height: 35, 
-                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/unlock.png", 
-                popupMessage: "Fully open access resource!" 
-            } 
+            {
+                x: 100, y: 80, width: 35, height: 35,
+                src: "https://raw.githubusercontent.com/IGOR-bioDGPs/ARIADNE/master/graph/imgs/unlock.png",
+                popupMessage: "Fully open access resource!"
+            }
         ];
-
         var loadedImages = [];
-        var imagesToLoad = shapes.filter(shape => shape.src).length;
+        var imagesToLoad = 0;
         var imagesLoaded = 0;
 
-        // Preload images
-        shapes.forEach(function(shape, index) {
-            if (shape.src) {
-                var img = new Image();
-                img.src = shape.src;
-                img.onload = function() {
-                    loadedImages[index] = img;
-                    imagesLoaded++;
-                    if (imagesLoaded === imagesToLoad) {
-                        drawShapes();
-                    }
-                };
+        // Function to initialize the shapes canvas
+        function initializeShapesCanvas() {
+            // Get the canvas element
+            canvas = document.getElementById("shapesCanvas");
+            if (!canvas) return;
+
+            ctx = canvas.getContext("2d");
+
+            // Reset image loading state
+            loadedImages = [];
+            imagesToLoad = shapes.filter(shape => shape.src).length;
+            imagesLoaded = 0;
+
+            // Preload images
+            shapes.forEach(function(shape, index) {
+                if (shape.src) {
+                    var img = new Image();
+                    img.src = shape.src;
+                    img.onload = function() {
+                        loadedImages[index] = img;
+                        imagesLoaded++;
+                        if (imagesLoaded === imagesToLoad) {
+                            drawShapes();
+                        }
+                    };
+                    img.onerror = function() {
+                        // Handle image loading errors
+                        console.warn("Failed to load image: " + shape.src);
+                        imagesLoaded++;
+                        if (imagesLoaded === imagesToLoad) {
+                            drawShapes();
+                        }
+                    };
+                }
+            });
+
+            // If there are no images to load, draw immediately
+            if (imagesToLoad === 0) {
+                drawShapes();
             }
-        });
+
+            // Remove existing event listeners to avoid duplicates
+            canvas.removeEventListener('mousemove', handleMouseMove);
+            canvas.removeEventListener('mouseleave', handleMouseLeave);
+
+            // Add event listeners
+            canvas.addEventListener('mousemove', handleMouseMove);
+            canvas.addEventListener('mouseleave', handleMouseLeave);
+        }
 
         // Draw shapes on the canvas
         function drawShapes() {
+            if (!ctx || !canvas) return;
             ctx.clearRect(0, 0, canvas.width, canvas.height);  // Clear the canvas completely
             shapes.forEach(function (shape, index) {
                 if (shape.src && loadedImages[index]) {
@@ -467,12 +500,12 @@
 
         // Function to show popup message
         function showPopup(message, x, y, c_width, c_height) {
+            if (!ctx || !canvas) return;
             var padding = 10;
             ctx.font = '12px Arial';
 
             // Determine the maximum width for the popup (e.g., a percentage of the canvas width)
             var maxPopupWidth = Math.min(200, canvas.width - 5 * padding);
-            // var maxPopupWidth = 500;
 
             // Split the message into lines if it exceeds the maximum width
             var words = message.split(' ');
@@ -496,7 +529,7 @@
                 var longestWord = wordList.reduce(function(a, b) {
                     return a.length > b.length ? a : b;
                 }, ""); // Find and return the longest word
-                
+
                 return longestWord;
             }
             var longestWord = getLongestWord(lines);
@@ -533,8 +566,9 @@
             });
         }
 
-        // Event listener for mouse movement
-        canvas.addEventListener('mousemove', function (e) {
+        // Event handler for mouse movement
+        function handleMouseMove(e) {
+            if (!ctx || !canvas) return;
             var mouseX = e.offsetX;
             var mouseY = e.offsetY;
             var popupShown = false;
@@ -565,14 +599,20 @@
                 ctx.clearRect(0, 0, canvas.width, canvas.height);
                 drawShapes();
             }
-        });
+        }
 
-        // Event listener to clear popup when mouse leaves the canvas
-        canvas.addEventListener("mouseleave", function () {
+        // Event handler to clear popup when mouse leaves the canvas
+        function handleMouseLeave() {
+            if (!ctx || !canvas) return;
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             drawShapes();
-});
-</script>
+        }
+
+        // Initialize canvas when the page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            initializeShapesCanvas();
+        });
+    </script>
 
 
 
@@ -822,7 +862,6 @@
                     <li>Tap on the resource nodes to go to the respective webpages.</li>
                     <li>Drag and drop on the nodes to rearrange the graph</li>
                     <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
-                    <canvas id="shapesCanvas" width="280" height="140"></canvas>
                 `;
             } else {
                 instructionsList.innerHTML = `
@@ -833,7 +872,6 @@
                     <li>Left click on the resource nodes to go to the respective webpages.</li>
                     <li>Drag and drop on the nodes to rearrange the graph</li>
                     <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
-                    <canvas id="shapesCanvas" width="280" height="140"></canvas>
                 `;
             }
         }
@@ -1144,89 +1182,164 @@
                 }
                 createNetwork(auxElem.replace(' ',''));
             }
+
+            // Function to handle terminal node interactions (hover/tap)
+            function handleTerminalNodeInteraction(node, isHover = true) {
+                if (node.data('is_terminal') == 'yes') {
+                    if (isHover) {
+                        // Desktop: hover over terminal node
+                        var tooltip = document.createElement('div');
+                        tooltip.className = 'custom-tooltip';
+                        tooltip.textContent = node.data('descr');
+                        document.body.appendChild(tooltip);
+
+                        const nodePosition = node.renderedPosition();
+                        const nodeHeight = node.renderedHeight();
+                        const nodeWidth = node.renderedWidth();
+                        const containerRect = cyto.container().getBoundingClientRect();
+                        tooltip.style.left = containerRect.left + window.scrollX + nodePosition.x - nodeWidth / 2 + 'px';
+                        tooltip.style.top = containerRect.top + window.scrollY + nodePosition.y + nodeHeight / 2 + 10 + 'px';
+                    } else {
+                        // Mobile: tap on terminal node - first tap shows tooltip, second tap navigates
+                        const existingTooltip = document.querySelector('.custom-tooltip');
+                        if (existingTooltip) {
+                            // Second tap - remove tooltip and navigate
+                            existingTooltip.remove();
+                            window.open(node.data('tooltip'), '_blank');
+                        } else {
+                            // First tap - show tooltip
+                            var tooltip = document.createElement('div');
+                            tooltip.className = 'custom-tooltip';
+                            tooltip.textContent = node.data('descr');
+                            document.body.appendChild(tooltip);
+
+                            const nodePosition = node.renderedPosition();
+                            const nodeHeight = node.renderedHeight();
+                            const nodeWidth = node.renderedWidth();
+                            const containerRect = cyto.container().getBoundingClientRect();
+                            tooltip.style.left = containerRect.left + window.scrollX + nodePosition.x - nodeWidth / 2 + 'px';
+                            tooltip.style.top = containerRect.top + window.scrollY + nodePosition.y + nodeHeight / 2 + 10 + 'px';
+                        }
+                    }
+                }
+            }
+
+            // Function to handle non-terminal node interactions
+            function handleNonTerminalNodeInteraction(node) {
+                cytoCSS.style.backgroundImage = 'url("")';
+                if (node.data('is_terminal') == 'no') {
+                    createNetwork(node.data('id').replaceAll(' ',''));
+                    if (node.data('mainGraph') == 'initial') {
+                        updateKeyContent(node, 'left_click');
+                    }
+                } else {
+                    window.open(node.data('tooltip'), '_blank');
+                }
+            }
+
             if (index == 0){ // if it's the first iteration
                 cyto = await createNetwork('initial'); // draw the initial overview
             }
             else{ // if it's not the first iteration
-                // if there is a left click on a node
+                // Desktop interactions
+                // Left click on a node → Move one level down (explore sub-graph)
                 cyto.on('click', 'node', function(event) {
-                    cytoCSS.style.backgroundImage = 'url("")'; // remove background image
-                    var node = event.target; // get the node
-                    if (node.data('is_terminal') == 'no'){ // if it's not a terminal node
-                        createNetwork(node.data('id').replaceAll(' ','')); // and give it to the network function as 'subgraph'
-                        if (node.data('mainGraph') == 'initial'){ // only if it's an initial node we should show the key questions
-                            updateKeyContent(node, 'left_click'); // Call the function to update key content
-                        }
+                    var node = event.target;
+                    if (node.data('is_terminal') == 'no') {
+                        // Non-terminal node - move one level down
+                        handleNonTerminalNodeInteraction(node);
+                    } else {
+                        // Terminal node - navigate to resource link
+                        window.open(node.data('tooltip'), '_blank');
                     }
-                    else{ // if it's a terminal node
-                        window.open(node.data('tooltip'), '_blank'); // redirect to the respective webpage
-                    }
-                });
-                // if there is a tap on a node; do the same as left click because mobile phones do not have left click
-                cyto.on('tap', 'node', function(event) {
-                    cytoCSS.style.backgroundImage = 'url("")'; // remove background image
-                    var node = event.target; // get the node
-                    if (node.data('is_terminal') == 'no'){ // if it's not a terminal node
-                        createNetwork(node.data('id').replaceAll(' ','')); // and give it to the network function as 'subgraph'
-                        if (node.data('mainGraph') == 'initial'){ // only if it's an initial node we should show the key questions
-                            updateKeyContent(node, 'left_click'); // Call the function to update key content
-                        }
-                    }
-                    else{ // if it's a terminal node
-                        window.open(node.data('tooltip'), '_blank'); // redirect to the respective webpage
-                    }
-                });
-                // if there is a right click anywhere
-                cyto.on('cxttap', function(event) {
-                    if (event.target !== cyto) return;
-                    cytoCSS.style.backgroundImage = 'url("ARIADNE_Logo.png")';
-                    const tooltips = document.querySelectorAll('.custom-tooltip');
-                    tooltips.forEach(tooltip => tooltip.remove());
-                    createNetwork('initial');
-                    updateKeyContent('', 'right_click');
-                    cyto.zoom(minZoom);
                 });
 
-                // if there is a right click on a node
+                // Hover over a terminal node → Display tooltip with resource description
+                cyto.on('mouseover', 'node', function(event) {
+                    const node = event.target;
+                    handleTerminalNodeInteraction(node, true); // true for hover
+                });
+
+                cyto.on('mouseout', 'node', function() {
+                    // Only remove tooltips on mouseout for desktop
+                    const tooltips = document.querySelectorAll('.custom-tooltip');
+                    tooltips.forEach(tooltip => tooltip.remove());
+                });
+
+                // Right click anywhere → Return to initial overview
+                cyto.on('cxttap', function(event) {
+                    if (event.target !== cyto) return;
+                    handleBackgroundContextAction(false);
+                });
+
+                // Right click on a node → Go one level up (back to parent graph)
                 cyto.on('cxttap', 'node', function(event) {
                     const node = event.target;
                     handleNodeContextAction(node);
                 });
-                // if there mouse is on a node
-                cyto.on('mouseover', 'node', function(event) {
+
+                // Mobile/Tablet interactions
+                // Tap on a non-terminal node → Move one level down (explore sub-graph)
+                // Tap on a terminal node (first tap) → Display tooltip with resource description
+                // Tap on a terminal node (second tap) → Hide tooltip and navigate to the resource link
+                let tapCount = 0;
+                let lastTapTime = 0;
+                let lastTapNode = null;
+
+                cyto.on('tap', 'node', function(event) {
                     const node = event.target;
-                    if (node.data('is_terminal') == 'yes'){ // and it's a terminal node
-                        var tooltip = document.createElement('div'); // create a tooltip div tag
-                        tooltip.className = 'custom-tooltip'; // using the respective CSS 
-                        tooltip.textContent = node.data('descr'); // and show the descriptions of the nodes
-                        document.body.appendChild(tooltip); // and append to the div tag created
-                        // Position the tooltip relative to the node's position and dimensions
-                        const nodePosition = node.renderedPosition(); // node's center in container coords
-                        const nodeHeight = node.renderedHeight(); // node's rendered height in screen coords
-                        const nodeWidth = node.renderedWidth(); // node's rendered width in screen coords
-                        const containerRect = cyto.container().getBoundingClientRect(); // container's offset on the page
-                        tooltip.style.left = containerRect.left + window.scrollX + nodePosition.x - nodeWidth / 2 + 'px';
-                        tooltip.style.top = containerRect.top + window.scrollY + nodePosition.y + nodeHeight / 2 + 10 + 'px';
+                    const currentTime = new Date().getTime();
+                    const tapInterval = currentTime - lastTapTime;
+
+                    // Check if it's a double tap on the same node (for going up)
+                    if (lastTapNode === node && tapInterval < 300) {
+                        // Double tap on node - go one level up
+                        handleNodeContextAction(node);
+                        tapCount = 0;
+                        lastTapTime = 0;
+                        lastTapNode = null;
+                        return;
+                    }
+
+                    // Regular tap handling
+                    lastTapNode = node;
+                    lastTapTime = currentTime;
+
+                    if (node.data('is_terminal') == 'no') {
+                        // Non-terminal node - move one level down
+                        handleNonTerminalNodeInteraction(node);
+                    } else {
+                        // Terminal node - handle tap interaction
+                        handleTerminalNodeInteraction(node, false); // false for tap
                     }
                 });
-                // if the mouse is moved outside of a node
-                cyto.on('mouseout', 'node', function() {
-                    const tooltips = document.querySelectorAll('.custom-tooltip'); // get all the boxes
-                    tooltips.forEach(tooltip => tooltip.remove()); // and remove them
-                });
-                // also we want to lock the amount of zoom
-                cyto.on('zoom', function(event) { // handle the zooming part
-                    const currentZoom = cyto.zoom();
-                    // limit the zoom level to the specified range
-                    if (currentZoom < minZoom) {
-                        cyto.zoom(minZoom); // set zoom to the minimum value
-                    } else if (currentZoom > maxZoom) {
-                        cyto.zoom(maxZoom); // set zoom to the maximum value
+
+                // Tap and hold anywhere → Return to initial overview
+                // Double tap on background → Return to initial overview
+                let backgroundTapCount = 0;
+                let lastBackgroundTapTime = 0;
+
+                cyto.on('tap', function(event) {
+                    // Check if background was tapped
+                    if (event.target === cyto) {
+                        const currentTime = new Date().getTime();
+                        const tapInterval = currentTime - lastBackgroundTapTime;
+
+                        // Check for double tap on background
+                        if (tapInterval < 300) {
+                            // Double tap on background - return to initial overview
+                            handleBackgroundContextAction(false);
+                            backgroundTapCount = 0;
+                            lastBackgroundTapTime = 0;
+                            return;
+                        }
+
+                        backgroundTapCount++;
+                        lastBackgroundTapTime = currentTime;
                     }
-                    cyto.center(); // center the whole graph to viewport 
                 });
-                // following block is for long press to go one level up alternative for mobile
-                // ===== MOBILE: Long-press handlers =====
+
+                // Long press handlers for mobile (already implemented but let's improve them)
                 let pressTimer;
                 let pressTarget = null;
 
@@ -1248,7 +1361,7 @@
                     } catch (error) {
                         var isNode = false;
                     }
-                    
+
                     if (!isNode && event.target === cyto) {
                         pressTimer = setTimeout(function() {
                             handleBackgroundContextAction(false);
@@ -1261,8 +1374,18 @@
                     clearTimeout(pressTimer);
                     pressTarget = null;
                 });
-                //
 
+                // also we want to lock the amount of zoom
+                cyto.on('zoom', function(event) { // handle the zooming part
+                    const currentZoom = cyto.zoom();
+                    // limit the zoom level to the specified range
+                    if (currentZoom < minZoom) {
+                        cyto.zoom(minZoom); // set zoom to the minimum value
+                    } else if (currentZoom > maxZoom) {
+                        cyto.zoom(maxZoom); // set zoom to the maximum value
+                    }
+                    cyto.center(); // center the whole graph to viewport
+                });
             }
         }
         function updateKeyContent(node, clickType) {
@@ -1324,6 +1447,26 @@
             }
         }
         main(index);
+
+        // Ensure instructions are loaded on initial page load
+        document.addEventListener('DOMContentLoaded', function() {
+            updateInstructionsByDeviceType();
+        });
+
+        // Also call it immediately in case DOM is already loaded
+        function initializePage() {
+            updateInstructionsByDeviceType();
+            // Also initialize the shapes canvas directly to ensure it works
+            setTimeout(initializeShapesCanvas, 100);
+        }
+
+        // Call it when DOM is loaded
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initializePage);
+        } else {
+            // DOM is already loaded
+            initializePage();
+        }
   </script>
 </body>
 </html>

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -366,17 +366,16 @@
             <button id="bug-ghub-button" class="bug-ghub-button" title="If you have a bug that you have encountered; please report them to us via GitHub issues!">Report a bug via GitHub</button>
         </div>
     </div>
-    
+
     <div id="cy"></div>
     <div id="info-box" class="info-box">
         <span id="infoTitle"><h2>Instructions:</h2> Click to hide/unhide the instructions</span>
         <div id="infoContent" hidden>
-            <ul>
-            <li>First things first. This is a "dynamic" network. This means that you can drag the nodes around and zoom in/out to resize the view</li>
+            <ul id="instructions-list">
             <li>Left click on a node to go to the next levels.</li>
             <li>Right click on anywhere to reset to the initial overview.</li>
             <li>Right click on a node to go back to the previous level in the network.</li>
-            <li>Hover on any resource node to reveal the information regarding the node.</li>
+            <li>Move mouse over terminal nodes for more details.</li>
             <li>Left click on the resource nodes to go to the respective webpages.</li>
             <li>Drag and drop on the nodes to rearrange the graph</li>
             <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
@@ -806,6 +805,42 @@
             return null;
         }
         }
+
+        // Device-aware function to update instructions based on device type
+        function updateInstructionsByDeviceType() {
+            var instructionsList = document.getElementById('instructions-list');
+            if (!instructionsList) return;
+            var isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+            var isTabletOrMobileWidth = window.innerWidth <= 1024;
+            var isMobileOrTablet = isTouchDevice || isTabletOrMobileWidth;
+
+            if (isMobileOrTablet) {
+                instructionsList.innerHTML = `
+                    <li>Tap on a node to go to the next levels.</li>
+                    <li>Long tap on anywhere to reset to the initial overview.</li>
+                    <li>Long tap on a node to go back to the previous level in the network.</li>
+                    <li>Tap on the resource nodes to go to the respective webpages.</li>
+                    <li>Drag and drop on the nodes to rearrange the graph</li>
+                    <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
+                    <canvas id="shapesCanvas" width="280" height="140"></canvas>
+                `;
+            } else {
+                instructionsList.innerHTML = `
+                    <li>Left click on a node to go to the next levels.</li>
+                    <li>Right click on anywhere to reset to the initial overview.</li>
+                    <li>Right click on a node to go back to the previous level in the network.</li>
+                    <li>Move mouse over terminal nodes for more details.</li>
+                    <li>Left click on the resource nodes to go to the respective webpages.</li>
+                    <li>Drag and drop on the nodes to rearrange the graph</li>
+                    <li>Here's the explanation of all the shapes, just hover over them to reveal the details:</li>
+                    <canvas id="shapesCanvas" width="280" height="140"></canvas>
+                `;
+            }
+        }
+
+
+
+
         // async function to get edges (local OR GitHub)
         async function fetchDataEdges() {
         try {
@@ -883,6 +918,7 @@
             // Update CSS variables for graph container size
             updateScreenDimensions();
             updateInfoBoxSize();
+            updateInstructionsByDeviceType();
             
             if (cyInstance) {
                 // Update node and edge styles based on new screen size
@@ -890,7 +926,7 @@
                 const edgeFontSize = Math.max(12, nodeFontSize - 4);
                 const textMaxWidth = window.innerWidth <= 600 ? 100 : 150;
                 const edgeTextMaxWidth = window.innerWidth <= 600 ? 60 : 100;
-                
+
                 // Apply updated styles
                 cyInstance.style()
                     .selector('node')
@@ -1094,12 +1130,17 @@
 
             // Shared function for context action on nodes
             function handleNodeContextAction(node) {
-                var auxElem = graphPathArr[index-1];
-                
-                if (auxElem != 'initial'){
-                    cytoCSS.style.backgroundImage = 'url("")';
-                } else if (auxElem == 'initial'){
+                const tooltips = document.querySelectorAll('.custom-tooltip');
+                tooltips.forEach(tooltip => tooltip.remove());
+                var auxElem = graphPathArr[index-2];
+                if (!auxElem) {
+                    auxElem = 'initial';
+                }
+                if (auxElem == 'initial'){
+                    cytoCSS.style.backgroundImage = 'url("ARIADNE_Logo.png")';
                     updateKeyContent('', 'right_click');
+                } else {
+                    cytoCSS.style.backgroundImage = 'url("")';
                 }
                 createNetwork(auxElem.replace(' ',''));
             }
@@ -1137,30 +1178,19 @@
                 });
                 // if there is a right click anywhere
                 cyto.on('cxttap', function(event) {
-                    try { // check if a node is clicked, or anywhere else
-                        var isNode = event.target.isNode(); // a variable that checks if a node is clicked
-                    } catch (error){
-                        var isNode = false;
-                    }
-                    cytoCSS.style.backgroundImage = 'url("ARIADNE_Logo.png")'; // add background image
-                    const tooltips = document.querySelectorAll('.custom-tooltip'); // get all tooltips, i.e. boxes
-                    tooltips.forEach(tooltip => tooltip.remove()); // and remove all of them
-                    createNetwork('initial'); // and reset to the initial overview
-                    if (!isNode) { // only reset if the reset screen right click appears
-                        updateKeyContent('', 'right_click'); // Call the function to update key content
-                    }
-                    cyto.zoom(minZoom); // set zoom to the minimum value
+                    if (event.target !== cyto) return;
+                    cytoCSS.style.backgroundImage = 'url("ARIADNE_Logo.png")';
+                    const tooltips = document.querySelectorAll('.custom-tooltip');
+                    tooltips.forEach(tooltip => tooltip.remove());
+                    createNetwork('initial');
+                    updateKeyContent('', 'right_click');
+                    cyto.zoom(minZoom);
                 });
+
                 // if there is a right click on a node
                 cyto.on('cxttap', 'node', function(event) {
                     const node = event.target;
-                    var auxElem = graphPathArr[index-1]; // get the previous subgraph
-                    if (auxElem != 'initial'){
-                        cytoCSS.style.backgroundImage = 'url("")'; // add background image
-                    } else if (auxElem == 'initial'){
-                        updateKeyContent('', 'right_click'); // Call the function to update key content
-                    }
-                    createNetwork(auxElem.replace(' ','')); // and reset to the initial overview
+                    handleNodeContextAction(node);
                 });
                 // if there mouse is on a node
                 cyto.on('mouseover', 'node', function(event) {

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -847,12 +847,16 @@
         }
 
         // Device-aware function to update instructions based on device type
+        function isMobileOrTabletDevice() {
+            var isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+            var isTabletOrMobileWidth = window.innerWidth <= 1024;
+            return isTouchDevice || isTabletOrMobileWidth;
+        }
+
         function updateInstructionsByDeviceType() {
             var instructionsList = document.getElementById('instructions-list');
             if (!instructionsList) return;
-            var isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
-            var isTabletOrMobileWidth = window.innerWidth <= 1024;
-            var isMobileOrTablet = isTouchDevice || isTabletOrMobileWidth;
+            var isMobileOrTablet = isMobileOrTabletDevice();
 
             if (isMobileOrTablet) {
                 instructionsList.innerHTML = `
@@ -1241,136 +1245,146 @@
                 cyto = await createNetwork('initial'); // draw the initial overview
             }
             else{ // if it's not the first iteration
-                // Desktop interactions
-                // Left click on a node → Move one level down (explore sub-graph)
-                cyto.on('click', 'node', function(event) {
-                    var node = event.target;
-                    if (node.data('is_terminal') == 'no') {
-                        // Non-terminal node - move one level down
-                        handleNonTerminalNodeInteraction(node);
-                    } else {
-                        // Terminal node - navigate to resource link
-                        window.open(node.data('tooltip'), '_blank');
-                    }
-                });
+                const isMobileOrTablet = isMobileOrTabletDevice();
 
-                // Hover over a terminal node → Display tooltip with resource description
-                cyto.on('mouseover', 'node', function(event) {
-                    const node = event.target;
-                    handleTerminalNodeInteraction(node, true); // true for hover
-                });
+                if (!isMobileOrTablet) {
+                    // Desktop interactions
+                    // Left click on a node → Move one level down (explore sub-graph)
+                    cyto.on('click', 'node', function(event) {
+                        var node = event.target;
+                        if (node.data('is_terminal') == 'no') {
+                            // Non-terminal node - move one level down
+                            handleNonTerminalNodeInteraction(node);
+                        } else {
+                            // Terminal node - navigate to resource link
+                            window.open(node.data('tooltip'), '_blank');
+                        }
+                    });
 
-                cyto.on('mouseout', 'node', function() {
-                    // Only remove tooltips on mouseout for desktop
-                    const tooltips = document.querySelectorAll('.custom-tooltip');
-                    tooltips.forEach(tooltip => tooltip.remove());
-                });
+                    // Hover over a terminal node → Display tooltip with resource description
+                    cyto.on('mouseover', 'node', function(event) {
+                        const node = event.target;
+                        handleTerminalNodeInteraction(node, true); // true for hover
+                    });
 
-                // Right click anywhere → Return to initial overview
-                cyto.on('cxttap', function(event) {
-                    if (event.target !== cyto) return;
-                    handleBackgroundContextAction(false);
-                });
+                    cyto.on('mouseout', 'node', function() {
+                        // Only remove tooltips on mouseout for desktop
+                        const tooltips = document.querySelectorAll('.custom-tooltip');
+                        tooltips.forEach(tooltip => tooltip.remove());
+                    });
 
-                // Right click on a node → Go one level up (back to parent graph)
-                cyto.on('cxttap', 'node', function(event) {
-                    const node = event.target;
-                    handleNodeContextAction(node);
-                });
+                    // Right click anywhere → Return to initial overview
+                    cyto.on('cxttap', function(event) {
+                        if (event.target !== cyto) return;
+                        handleBackgroundContextAction(false);
+                    });
 
-                // Mobile/Tablet interactions
-                // Tap on a non-terminal node → Move one level down (explore sub-graph)
-                // Tap on a terminal node (first tap) → Display tooltip with resource description
-                // Tap on a terminal node (second tap) → Hide tooltip and navigate to the resource link
-                let tapCount = 0;
-                let lastTapTime = 0;
-                let lastTapNode = null;
-
-                cyto.on('tap', 'node', function(event) {
-                    const node = event.target;
-                    const currentTime = new Date().getTime();
-                    const tapInterval = currentTime - lastTapTime;
-
-                    // Check if it's a double tap on the same node (for going up)
-                    if (lastTapNode === node && tapInterval < 300) {
-                        // Double tap on node - go one level up
+                    // Right click on a node → Go one level up (back to parent graph)
+                    cyto.on('cxttap', 'node', function(event) {
+                        const node = event.target;
                         handleNodeContextAction(node);
-                        tapCount = 0;
-                        lastTapTime = 0;
-                        lastTapNode = null;
-                        return;
-                    }
+                    });
+                } else {
+                    // Mobile/Tablet interactions
+                    // Tap on a non-terminal node → Move one level down (explore sub-graph)
+                    // Tap on a terminal node (first tap) → Display tooltip with resource description
+                    // Tap on a terminal node (second tap) → Hide tooltip and navigate to the resource link
+                    let tapCount = 0;
+                    let lastTapTime = 0;
+                    let lastTapNode = null;
 
-                    // Regular tap handling
-                    lastTapNode = node;
-                    lastTapTime = currentTime;
-
-                    if (node.data('is_terminal') == 'no') {
-                        // Non-terminal node - move one level down
-                        handleNonTerminalNodeInteraction(node);
-                    } else {
-                        // Terminal node - handle tap interaction
-                        handleTerminalNodeInteraction(node, false); // false for tap
-                    }
-                });
-
-                // Tap and hold anywhere → Return to initial overview
-                // Double tap on background → Return to initial overview
-                let backgroundTapCount = 0;
-                let lastBackgroundTapTime = 0;
-
-                cyto.on('tap', function(event) {
-                    // Check if background was tapped
-                    if (event.target === cyto) {
+                    cyto.on('tap', 'node', function(event) {
+                        const node = event.target;
                         const currentTime = new Date().getTime();
-                        const tapInterval = currentTime - lastBackgroundTapTime;
+                        const tapInterval = currentTime - lastTapTime;
 
-                        // Check for double tap on background
-                        if (tapInterval < 300) {
-                            // Double tap on background - return to initial overview
-                            handleBackgroundContextAction(false);
-                            backgroundTapCount = 0;
-                            lastBackgroundTapTime = 0;
+                        // Check if it's a double tap on the same node (for going up)
+                        if (lastTapNode === node && tapInterval < 300) {
+                            // Double tap on node - go one level up
+                            handleNodeContextAction(node);
+                            tapCount = 0;
+                            lastTapTime = 0;
+                            lastTapNode = null;
                             return;
                         }
 
-                        backgroundTapCount++;
-                        lastBackgroundTapTime = currentTime;
-                    }
-                });
+                        // Regular tap handling
+                        lastTapNode = node;
+                        lastTapTime = currentTime;
 
-                // Long press handlers for mobile (already implemented but let's improve them)
-                let pressTimer;
-                let pressTarget = null;
+                        if (node.data('is_terminal') == 'no') {
+                            // Non-terminal node - move one level down
+                            handleNonTerminalNodeInteraction(node);
+                        } else {
+                            // Terminal node - handle tap interaction
+                            handleTerminalNodeInteraction(node, false); // false for tap
+                        }
+                    });
 
-                // Long-press on node
-                cyto.on('tapstart', 'node', function(event) {
-                    const node = event.target;
-                    pressTarget = node;
-                    pressTimer = setTimeout(function() {
-                        handleNodeContextAction(node);
-                        pressTarget = null;
-                    }, 600);
-                });
+                    // Tap and hold anywhere → Return to initial overview
+                    // Double tap on background → Return to initial overview
+                    let backgroundTapCount = 0;
+                    let lastBackgroundTapTime = 0;
 
-                // Long-press on background
-                cyto.on('tapstart', function(event) {
-                    // Check if it's the background (not a node or edge)
-                    try {
-                        var isNode = event.target.isNode();
-                    } catch (error) {
-                        var isNode = false;
-                    }
+                    cyto.on('tap', function(event) {
+                        // Check if background was tapped
+                        if (event.target === cyto) {
+                            const currentTime = new Date().getTime();
+                            const tapInterval = currentTime - lastBackgroundTapTime;
 
-                    if (!isNode && event.target === cyto) {
+                            // Check for double tap on background
+                            if (tapInterval < 300) {
+                                // Double tap on background - return to initial overview
+                                handleBackgroundContextAction(false);
+                                backgroundTapCount = 0;
+                                lastBackgroundTapTime = 0;
+                                return;
+                            }
+
+                            backgroundTapCount++;
+                            lastBackgroundTapTime = currentTime;
+                        }
+                    });
+
+                    // Long press handlers for mobile (already implemented but let's improve them)
+                    let pressTimer;
+                    let pressTarget = null;
+
+                    // Long-press on node
+                    cyto.on('tapstart', 'node', function(event) {
+                        const node = event.target;
+                        pressTarget = node;
                         pressTimer = setTimeout(function() {
-                            handleBackgroundContextAction(false);
+                            handleNodeContextAction(node);
+                            pressTarget = null;
                         }, 600);
-                    }
-                });
+                    });
 
-                // Cancel long-press on tap end or drag
-                cyto.on('tapend drag', function() {
+                    // Long-press on background
+                    cyto.on('tapstart', function(event) {
+                        // Check if it's the background (not a node or edge)
+                        try {
+                            var isNode = event.target.isNode();
+                        } catch (error) {
+                            var isNode = false;
+                        }
+
+                        if (!isNode && event.target === cyto) {
+                            pressTimer = setTimeout(function() {
+                                handleBackgroundContextAction(false);
+                            }, 600);
+                        }
+                    });
+
+                    // Cancel long-press on tap end or drag
+                    cyto.on('tapend drag', function() {
+                        clearTimeout(pressTimer);
+                        pressTarget = null;
+                    });
+                }
+
+                // also we want to lock the amount of zoom
+                cyto.on('zoom', function(event) { // handle the zooming part
                     clearTimeout(pressTimer);
                     pressTarget = null;
                 });

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -1171,11 +1171,12 @@
                         tooltip.textContent = node.data('descr'); // and show the descriptions of the nodes
                         document.body.appendChild(tooltip); // and append to the div tag created
                         // Position the tooltip relative to the node's position and dimensions
-                        const nodePosition = node.renderedPosition(); // node's position
-                        const nodeHeight = node.height(); // node's height
-                        const nodeWidth = node.width(); // node's width
-                        tooltip.style.left = nodePosition.x + 'px'; // distance from left
-                        tooltip.style.top = nodePosition.y + nodeHeight + 10 + 'px'; // distance from top
+                        const nodePosition = node.renderedPosition(); // node's center in container coords
+                        const nodeHeight = node.renderedHeight(); // node's rendered height in screen coords
+                        const nodeWidth = node.renderedWidth(); // node's rendered width in screen coords
+                        const containerRect = cyto.container().getBoundingClientRect(); // container's offset on the page
+                        tooltip.style.left = containerRect.left + window.scrollX + nodePosition.x - nodeWidth / 2 + 'px';
+                        tooltip.style.top = containerRect.top + window.scrollY + nodePosition.y + nodeHeight / 2 + 10 + 'px';
                     }
                 });
                 // if the mouse is moved outside of a node


### PR DESCRIPTION
Makes the graph visualization page responsive for mobile, tablet, and large desktop screens.

Fixes a sub issue of #6 

Breakpoints

- Mobile (≤600px): 70% viewport height, compact buttons, smaller fonts (11-16px)
- Tablet (≤900px): 80% viewport height, moderate sizing (13px fonts)
- Desktop (≥1200px): 90% viewport height, larger fonts (16-18px)

